### PR TITLE
Fix env variable name in test skip warning

### DIFF
--- a/t/net_redmine_test.pl
+++ b/t/net_redmine_test.pl
@@ -2,7 +2,7 @@ use Test::More;
 use Cwd 'getcwd';
 
 unless ($_ = $ENV{NET_REDMINE_RAILS_ROOT}) {
-    plan skip_all => "Need SD_REDMINE_RAILS_ROOT env var";
+    plan skip_all => "Need NET_REDMINE_RAILS_ROOT env var";
     exit;
 }
 


### PR DESCRIPTION
The name of the environment variable expected in order to run the
net_redmine_test.pl tests is called `NET_REDMINE_RAILS_ROOT`.  This change
corrects the current warning message which mentions `SD_REDMINE_RAILS_ROOT`
to the expected value mentioned in the code.

This pull request is submitted in the hope that it is useful.  If there are any questions or comments concerning it, please don't hesitate to contact me.

This pull request is also submitted as part of the [CPAN Pull Request Challenge](http://cpan-prc.org/)